### PR TITLE
Fix typing for return data of compress and decompress

### DIFF
--- a/module.d.ts
+++ b/module.d.ts
@@ -30,15 +30,20 @@ export interface EncodeOptions extends BufferSizeOptions {
   quality?: number;
 }
 
+export interface CompressReturn {
+  data: Buffer;
+  size: number;
+}
+
 export function bufferSize(options: BufferSizeOptions): number;
 export function compressSync(raw: Buffer, options: EncodeOptions): Buffer;
 export function compressSync(raw: Buffer, preallocatedOut: Buffer, options: EncodeOptions): Buffer;
-export function compress(raw: Buffer, options: EncodeOptions, callback: (err: any, image: Buffer) => void): void;
+export function compress(raw: Buffer, options: EncodeOptions, callback: (err: any, image: CompressReturn) => void): void;
 export function compress(
   raw: Buffer,
   preallocatedOut: Buffer,
   options: EncodeOptions,
-  callback: (err: any, image: Buffer) => void
+  callback: (err: any, image: CompressReturn) => void
 ): void;
 
 export interface DecodeOptions {
@@ -52,6 +57,14 @@ export interface DecodeResult {
   format: any;
 }
 
+export interface DecompressReturn {
+  data: Buffer;
+  width: number;
+  height: number;
+  size: number;
+  format: Format;
+}
+
 export function decompressSync(image: Buffer, preallocatedOut: Buffer, options?: DecodeOptions): DecodeResult;
 export function decompressSync(image: Buffer, options?: DecodeOptions): DecodeResult;
 
@@ -59,11 +72,11 @@ export function decompress(
   image: Buffer,
   preallocatedOut: Buffer,
   options: DecodeOptions,
-  callback: (err: any, image: Buffer) => void
+  callback: (err: any, image: DecompressReturn) => void
 ): DecodeResult;
 export function decompress(
   image: Buffer,
   options: DecodeOptions,
-  callback: (err: any, image: Buffer) => void
+  callback: (err: any, image: DecompressReturn) => void
 ): DecodeResult;
-export function decompress(image: Buffer, callback: (err: any, image: Buffer) => void): DecodeResult;
+export function decompress(image: Buffer, callback: (err: any, image: DecompressReturn) => void): DecodeResult;


### PR DESCRIPTION
```cpp
      Local<Object> obj = New<Object>();
      Nan::Set(obj, New("data").ToLocalChecked(), dstObject);
      Nan::Set(obj, New("size").ToLocalChecked(), New((uint32_t) this->jpegSize));
      v8::Local<v8::Value> argv[] = {
        Nan::Null(),
        obj
      };

      callback->Call(2, argv, async_resource);
```

The return type of callback does not look like Buffer or ArrayBuffer but an object with attributes.