### PR TITLE
fix: Unexpected end of file in electron-rebuild

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,2 +1,7 @@
 # Hack to force electron-builder to realise this is a native dependency
 # https://github.com/electron-userland/electron-builder/issues/3938
+{
+  'targets': [{
+    'target_name': 'binding.gyp'      
+  }]
+}


### PR DESCRIPTION
This seems to fix the 'unexpected end of file' when electron-rebuild happens.